### PR TITLE
fix type hints and formatting

### DIFF
--- a/pyjsx/__init__.py
+++ b/pyjsx/__init__.py
@@ -4,4 +4,4 @@ from pyjsx.transpiler import transpile
 
 
 __version__ = "0.1.0"
-__all__ = ["register_jsx", "transpile", "jsx", "JSX", "JSXComponent"]
+__all__ = ["JSX", "JSXComponent", "jsx", "register_jsx", "transpile"]

--- a/pyjsx/codecs.py
+++ b/pyjsx/codecs.py
@@ -1,11 +1,19 @@
+from __future__ import annotations  # noqa: A005
+
 import codecs
 import encodings
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from _typeshed import ReadableBuffer
 
 from pyjsx.transpiler import transpile
 
 
-def pyjsx_decode(input: memoryview, errors: str = "strict") -> tuple[str, int]:  # noqa: A002, ARG001
-    return transpile(bytes(input).decode("utf-8")), len(input)
+def pyjsx_decode(input: ReadableBuffer, errors: str = "strict") -> tuple[str, int]:  # noqa: A002, ARG001
+    byte_content = bytes(input)
+    return transpile(byte_content.decode("utf-8")), len(byte_content)
 
 
 def pyjsx_search_function(encoding: str) -> codecs.CodecInfo | None:

--- a/pyjsx/codecs.py
+++ b/pyjsx/codecs.py
@@ -1,4 +1,4 @@
-from __future__ import annotations  # noqa: A005
+from __future__ import annotations
 
 import codecs
 import encodings

--- a/pyjsx/jsx.py
+++ b/pyjsx/jsx.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 from typing import Any, Protocol, TypeAlias
 
 from pyjsx.elements import is_void_element

--- a/pyjsx/tokenizer.py
+++ b/pyjsx/tokenizer.py
@@ -216,7 +216,7 @@ class Tokenizer:
             yield Token(TokenType.JSX_TEXT, text, self.curr, self.curr + len(text))
             self.curr += len(text)
         else:
-            msg = f"Unexpected token {self.source[self.curr:]}"
+            msg = f"Unexpected token {self.source[self.curr :]}"
             raise TokenizerError(msg)
 
     def tokenize_py(self) -> Generator[Token, None, None]:  # noqa: C901, PLR0912, PLR0915
@@ -386,6 +386,6 @@ class Tokenizer:
                 else:
                     break
             if not middle:
-                msg = f"Unexpected token {self.source[self.curr:]}"
+                msg = f"Unexpected token {self.source[self.curr :]}"
                 raise TokenizerError(msg)
             yield Token(TokenType.FSTRING_MIDDLE, middle, self.curr, self.curr + len(middle))


### PR DESCRIPTION
- sort __all__ in __init__.py alphabetically
- fix formatting (ruff) in tokenizer.py
- remove unused import in jsx.py
- replace memoryview with ReadableBuffer in codecs.py

only the last point (memoryview -> ReadableBuffer) is worth looking at IMHO - tests still pass.

I could add tox (with uv-tox) if you like for local matrix testing with all the different python versions.