### PR TITLE
Add mypy plugin and py.typed file

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,26 @@ header = <Header>Title</Header>
 print(header)
 ```
 
+## Type checking
+
+PyJSX includes a plugin that allows mypy to parse files with JSX in them. To
+use it, add `pyjsx.mypy` to the `plugins` list in your [mypy configuration
+file][mypy]. For example, in `mypy.ini`:
+
+```ini
+[mypy]
+plugins = pyjsx.mypy
+```
+
+Or in `pyproject.toml`:
+
+```toml
+[tool.mypy]
+plugins = ["pyjsx.mypy"]
+```
+
+[mypy]: https://mypy.readthedocs.io/en/stable/config_file.html
+
 ## Prior art
 
 Inspired by [packed](https://github.com/michaeljones/packed) and

--- a/pyjsx/mypy.py
+++ b/pyjsx/mypy.py
@@ -1,0 +1,9 @@
+from mypy.plugin import Plugin
+
+
+class PyJSXPlugin(Plugin):
+    from pyjsx import auto_setup  # type: ignore[import-unused]
+
+
+def plugin(_version: str) -> type[Plugin]:
+    return PyJSXPlugin


### PR DESCRIPTION
The mypy plugin is just a trick to get mypy to import `auto_setup` before importing the files it's typechecking (without this, you see a lot of `mypy: can't decode file 'foo.py': unknown encoding: jsx`). People can use it by adding `pyjsx.mypy` to the `plugins` list in their `mypy.ini`/ `pyproject.toml`.

The `py.typed` file simply tells mypy that it can use the package's annotations when it checks types. This avoids

    error: Skipping analyzing "pyjsx.jsx": module is installed, but missing library stubs or py.typed marker  [import-untyped]

See https://peps.python.org/pep-0561/#packaging-type-information