### PR TITLE
No Textarea Indent

### DIFF
--- a/pyjsx/elements.py
+++ b/pyjsx/elements.py
@@ -1,3 +1,22 @@
+# Elements whose text content must not be altered by pretty-printing.
+# See https://html.spec.whatwg.org/multipage/parsing.html#parsing-html-fragments
+rcdata_elements = {
+    "textarea",
+    "title",
+}
+
+rawtext_elements = {
+    "script",
+    "style",
+    "iframe",
+    "noembed",
+    "noframes",
+    "noscript",
+    "xmp",
+}
+
+text_content_elements = rcdata_elements | rawtext_elements
+
 void_elements = {
     "area",
     "base",
@@ -139,6 +158,10 @@ builtin_elements = {
 
 def is_void_element(tag: str) -> bool:
     return tag in void_elements
+
+
+def is_text_content_element(tag: str) -> bool:
+    return tag in text_content_elements
 
 
 def is_builtin_element(tag: str) -> bool:

--- a/pyjsx/jsx.py
+++ b/pyjsx/jsx.py
@@ -4,8 +4,8 @@ import html
 import re
 from typing import Any, Protocol, TypeAlias
 
-from pyjsx.elements import is_void_element
-from pyjsx.util import flatten, indent
+from pyjsx.elements import is_text_content_element, is_void_element
+from pyjsx.util import flatten, indent, indent_first_line_only
 
 
 __all__ = ["jsx"]
@@ -125,9 +125,20 @@ class _JSXElement:
             if is_void_element(tag):
                 return f"<{tag}{props} />"
             return f"<{tag}{props}></{tag}>"
+        if is_text_content_element(tag):
+            children_formatted = "".join(
+                _escape(child) if isinstance(child, str) else str(child) for child in children
+            )
+            return f"<{tag}{props}>{children_formatted}</{tag}>"
+
         children = [_escape(child) if isinstance(child, str) else child for child in children]
-        children_formatted = "\n".join(indent(str(child)) for child in children)
+        children_formatted = "\n".join(self._format_pretty_child(child) for child in children)
         return f"<{tag}{props}>\n{children_formatted}\n</{tag}>"
+
+    def _format_pretty_child(self, child: JSX) -> str:
+        if isinstance(child, _JSXElement) and isinstance(child.tag, str) and is_text_content_element(child.tag):
+            return indent_first_line_only(str(child))
+        return indent(str(child))
 
     def render_custom_component(self, tag: JSXComponent | JSXFragment) -> str:
         """Render a custom component which is a callable that returns JSX."""

--- a/pyjsx/util.py
+++ b/pyjsx/util.py
@@ -16,6 +16,13 @@ def indent(text: str, spaces: int = 4) -> str:
     return "\n".join(f"{' ' * spaces}{line}" for line in text.split("\n"))
 
 
+def indent_first_line_only(text: str, spaces: int = 4) -> str:
+    lines = text.split("\n")
+    if len(lines) == 1:
+        return f"{' ' * spaces}{lines[0]}"
+    return f"{' ' * spaces}{lines[0]}\n" + "\n".join(lines[1:])
+
+
 def flatten(children: Iterable[Nested[T]]) -> Generator[T]:
     for child in children:
         if isinstance(child, list | tuple):

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -1,6 +1,21 @@
 import pytest
 
-from pyjsx.elements import is_builtin_element
+from pyjsx.elements import is_builtin_element, is_text_content_element
+
+
+@pytest.mark.parametrize(
+    ("elem", "is_text_content"),
+    [
+        ("textarea", True),
+        ("title", True),
+        ("script", True),
+        ("style", True),
+        ("div", False),
+        ("span", False),
+    ],
+)
+def test_text_content_elements(elem: str, *, is_text_content: bool):
+    assert is_text_content_element(elem) == is_text_content
 
 
 @pytest.mark.parametrize(

--- a/tests/test_jsx.py
+++ b/tests/test_jsx.py
@@ -101,3 +101,41 @@ def test_attribute_escapes(source: str, expected: str):
 )
 def test_custom_elements_rendering(source: str, expected: str):
     assert str(source) == expected
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        (
+            jsx("textarea", {"name": "body"}, ["line1\n\nline2"]),
+            '<textarea name="body">line1\n\nline2</textarea>',
+        ),
+        (
+            jsx("script", {}, ['console.log("hi")']),
+            "<script>console.log(&quot;hi&quot;)</script>",
+        ),
+        (
+            jsx("style", {}, ["body { margin: 0; }"]),
+            "<style>body { margin: 0; }</style>",
+        ),
+        (
+            jsx("title", {}, ["Page Title"]),
+            "<title>Page Title</title>",
+        ),
+        (
+            jsx(
+                "form",
+                {},
+                [jsx("textarea", {"name": "body"}, ["line1\n\nline2"])],
+            ),
+            """\
+<form>
+    <textarea name="body">line1
+
+line2</textarea>
+</form>""",
+        ),
+    ],
+)
+def test_text_content_elements_rendering(source: str, expected: str):
+    assert str(source) == expected


### PR DESCRIPTION
Do not indent plain string children, at least for RCDATA/RAWTEXT elements like <textarea>.
Solves Issue [#44](https://github.com/tomasr8/pyjsx/issues/44) 